### PR TITLE
support for node>v0.5.X

### DIFF
--- a/raptor.js
+++ b/raptor.js
@@ -1,0 +1,37 @@
+var events = require('events');
+var raptorTarget = require(__dirname + '/build/Release/raptor.node');
+
+
+function inherits(target, source) {
+    for (var k in source.prototype)
+        target[k] = source.prototype[k];
+}
+
+
+exports.newParser = function(mimeType, cb) {
+    if(cb==null) {
+        var parser = raptorTarget.newParser(mimeType);
+        inherits(parser, events.EventEmitter);
+        return parser;
+    } else {
+        var res = raptorTarget.newParser(mimeType, function(parser) {
+            inherits(parser, events.EventEmitter);
+            cb(parser);
+        });
+    }
+}
+
+
+exports.newSerializer = function(mimeType) {
+    var serializer = null;
+
+    if(mimeType == null) {
+        serializer = raptorTarget.newSerializer();
+    } else {
+        serializer = raptorTarget.newSerializer(mimeType);
+    }
+
+    inherits(serializer, events.EventEmitter);
+
+    return serializer;
+}

--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -24,6 +24,6 @@ using namespace node;
 
 /* extern "C" to prevent name mangling */
 extern "C" void init(Handle<Object> target) {
-    NODE_SET_METHOD(target, "newParser", Parser::Initialize);
-    NODE_SET_METHOD(target, "newSerializer", Serializer::Initialize);
+  NODE_SET_METHOD(target, "newParser", Parser::Initialize);
+  NODE_SET_METHOD(target, "newSerializer", Serializer::Initialize);
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -18,7 +18,8 @@
 #define NODE_RAPTOR_PARSER_H_
 
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
+//#include <node_events.h>
 #include <raptor.h>
 
 #include "statics.h"
@@ -32,7 +33,8 @@ enum parser_state {
 using namespace v8;
 using namespace node;
 
-class Parser : public EventEmitter {
+//class Parser : public EventEmitter {
+class Parser : public ObjectWrap {
 public:
     static Handle<Value> Initialize(const Arguments& args);
     static Handle<Value> New(const Arguments& args);
@@ -51,6 +53,7 @@ public:
     Parser(const char* name);
     ~Parser();
 protected:
+
     void Abort();
     
     void ParseFile(const char* filename, const char* base);

--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -26,7 +26,7 @@ Handle<Value> Serializer::Initialize(const Arguments& args) {
 
     Handle<FunctionTemplate> t = FunctionTemplate::New(New);
 
-    t->Inherit(EventEmitter::constructor_template);
+    //t->Inherit(EventEmitter::constructor_template);
     t->InstanceTemplate()->SetInternalFieldCount(1);
 
     NODE_SET_PROTOTYPE_METHOD(t, "serializeToFile", SerializeToFile);
@@ -303,12 +303,40 @@ void Serializer::SerializeEnd() {
         statement_string_ = NULL;
     }
     
-    Handle<Value> args[1];
-    args[0] = data;
+    //Handle<Value> args[1];
+    //args[0] = data;
     
     // TODO: serialize in chunks w/ raptor_new_iostream_from_handler?
-    Emit(data_symbol, 1, args);
-    Emit(end_symbol, 0, NULL);
+    Local<Value> emit_v = this->handle_->Get(String::NewSymbol("emit"));
+    assert(emit_v->IsFunction());
+    Local<Function> emit_f = emit_v.As<Function>();
+
+    Handle<Value> argv[2] = {
+      String::New("data"),
+      data
+    };
+
+    TryCatch tc;
+
+    emit_f->Call(this->handle_, 2, argv);
+
+    if (tc.HasCaught())
+      FatalException(tc);
+
+    Handle<Value> argv2[1] = {
+      String::New("end")
+    };
+
+    TryCatch tc2;
+
+    emit_f->Call(this->handle_, 1, argv2);
+
+    if (tc2.HasCaught())
+      FatalException(tc);
+
+
+    //Emit(data_symbol, 1, args);
+    //Emit(end_symbol, 0, NULL);
 }
 
 void Serializer::SetNamespace(const char* prefix, const char* nspace) {

--- a/src/serializer.h
+++ b/src/serializer.h
@@ -18,7 +18,8 @@
 #define NODE_RAPTOR_SERIALIZER_H_
 
 #include <node.h>
-#include <node_events.h>
+//#include <node_events.h>
+#include <node_object_wrap.h>
 #include <raptor.h>
 
 using namespace v8;
@@ -29,7 +30,7 @@ enum serializer_state {
     SERIALIZER_STATE_SERIALIZING, 
 };
 
-class Serializer : public EventEmitter {
+class Serializer : public ObjectWrap {
 public:
     static Handle<Value> Initialize(const Arguments& args);
     static Handle<Value> New(const Arguments& args);

--- a/test/parse.js
+++ b/test/parse.js
@@ -16,8 +16,8 @@
 
 const MAX_STATEMENTS = Number.MAX_VALUE;
 
-var util    = require('util'), 
-    raptor  = require('./../build/default/raptor');
+var util    = require('util');
+var raptor = require('./../raptor');
 
 var time;
 

--- a/test/parse_buffer.js
+++ b/test/parse_buffer.js
@@ -18,7 +18,7 @@ const MAX_STATEMENTS = Number.MAX_VALUE;
 
 var util    = require('util'), 
     fs      = require('fs'), 
-    raptor  = require('./../build/default/raptor');
+    raptor  = require('./../raptor.js');
 
 var time;
 var filename = process.argv[2];

--- a/test/parse_uri.js
+++ b/test/parse_uri.js
@@ -18,7 +18,7 @@ const fileURI = 'http://xmlns.com/foaf/spec/index.rdf';
 const MAX_STATEMENTS = Number.MAX_VALUE;
 
 var util    = require('util'), 
-    raptor  = require('./../build/default/raptor');
+    raptor  = require('./../raptor');
 
 var time;
 

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -15,19 +15,19 @@
  */
 
 var util    = require('util'), 
-    raptor  = require('./../build/default/raptor'), 
+    raptor  = require('./../raptor'), 
     fs      = require('fs');
 
 var s = {
     subject:    {value: 'http://example.com/resource1', type: 'uri'}, 
     predicate:  {value: 'http://xmlns.com/foaf/0.1/name', type: 'uri'}, 
-    object:     {value: 'Resource One', type: 'literal'}
+    object:     {value: 'Resource One', language: 'en', type: 'literal'}
 }
 
 var s2 = {
     subject:   {value: '_:123', type: 'bnode'}, 
     predicate: {value: 'http://ns.aksw.org/scms#beginIndex', type: 'uri'}, 
-    object:    {value: '31', datatype: 'http://www.w3.org/2001/XMLSchema#int', lang: 'de'}
+    object:    {value: '31', datatype: 'http://www.w3.org/2001/XMLSchema#int', type:'typed-literal'}
 }
 
 /*
@@ -60,7 +60,7 @@ var serializer = raptor.newSerializer('turtle');
 
 process.nextTick(function () {
     serializer.serializeStart();
-    // serializer.serializeStatement(s);
+    //serializer.serializeStatement(s);
     serializer.serializeStatement(s2);
     serializer.serializeEnd();
 });


### PR DESCRIPTION
Hi, I had some problems trying your code with the latest version of Node.

I think the problem are the changes in the events API in Node. 

I've been using this modified version of the code with Nodev > 0.5.11 up to 0.6.6 and seems to work OK. I'm not the greatest C++ coder though.

Additionally, have you considered packaging the library for NPM?

Regards.
